### PR TITLE
Add Vite config and npm metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+unpackage/
+.hbuilderx/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gusu-made",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev:mp-weixin": "uni -p mp-weixin",
+    "dev:h5": "uni",
+    "build:mp-weixin": "uni build -p mp-weixin",
+    "build:h5": "uni build -p h5"
+  },
+  "devDependencies": {
+    "@dcloudio/vite-plugin-uni": "^0.7.0",
+    "unplugin-vue-components": "^0.24.1",
+    "vite": "^4.0.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import uni from '@dcloudio/vite-plugin-uni'
+import Components from 'unplugin-vue-components/vite'
+import { UviewPlusResolver } from 'unplugin-vue-components/resolvers'
+
+export default defineConfig({
+  plugins: [
+    uni(),
+    Components({
+      resolvers: [UviewPlusResolver()]
+    })
+  ]
+})
+


### PR DESCRIPTION
## Summary
- ignore build artifacts and node modules
- add `package.json` with dev dependencies and scripts
- add `vite.config.js` with `UviewPlusResolver`

## Testing
- `npm run dev:h5` *(fails: uni command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850571faf6c8327b51a5f9225eab3b3