### PR TITLE
Add license and engine fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Gusu Made is a UniApp project designed to provide a seamless user experience acr
 
 ## Installation
 1. Clone the repository.
-2. Open the project in HBuilderX.
-3. Install dependencies using `npm install`.
+2. Ensure you have Node.js 14 or later installed.
+3. Open the project in HBuilderX.
+4. Install dependencies using `npm install`.
 
 ## Usage
 - Run the project locally using HBuilderX.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "gusu-made",
   "version": "1.0.0",
   "private": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "dev:mp-weixin": "uni -p mp-weixin",
     "dev:h5": "uni",


### PR DESCRIPTION
## Summary
- specify Apache-2.0 license and Node engine version in `package.json`
- note Node.js ≥14 requirement in README

## Testing
- `npm test` *(fails: Missing script / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852a156f9888327abe8f91903a3502e