### PR TITLE
Add starter pages and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Gusu Made is a UniApp project designed to provide a seamless user experience acr
 - Centralized configuration management with `uni-config-center`
 - Customizable styles using SCSS variables
 - Easy integration with UniCloud database and cloud functions
+- Starter pages for customization, template marketplace, product store and
+  user profile
 
 ## Installation
 1. Clone the repository.

--- a/pages.json
+++ b/pages.json
@@ -1,17 +1,41 @@
 {
-	"pages": [ //pages数组中第一项表示应用启动页，参考：https://uniapp.dcloud.io/collocation/pages
-		{
-			"path": "pages/index/index",
-			"style": {
-				"navigationBarTitleText": "谷苏良匠"
-			}
-		}
-	],
-	"globalStyle": {
-		"navigationBarTextStyle": "black",
-		"navigationBarTitleText": "uni-app",
-		"navigationBarBackgroundColor": "#F8F8F8",
-		"backgroundColor": "#F8F8F8"
-	},
-	"uniIdRouter": {}
+  "pages": [
+    {
+      "path": "pages/index/index",
+      "style": {
+        "navigationBarTitleText": "谷苏良匠"
+      }
+    },
+    {
+      "path": "pages/customize/index",
+      "style": {
+        "navigationBarTitleText": "周边定制"
+      }
+    },
+    {
+      "path": "pages/templates/index",
+      "style": {
+        "navigationBarTitleText": "模板市场"
+      }
+    },
+    {
+      "path": "pages/store/index",
+      "style": {
+        "navigationBarTitleText": "成品商城"
+      }
+    },
+    {
+      "path": "pages/profile/index",
+      "style": {
+        "navigationBarTitleText": "我的"
+      }
+    }
+  ],
+  "globalStyle": {
+    "navigationBarTextStyle": "black",
+    "navigationBarTitleText": "uni-app",
+    "navigationBarBackgroundColor": "#F8F8F8",
+    "backgroundColor": "#F8F8F8"
+  },
+  "uniIdRouter": {}
 }

--- a/pages/customize/index.vue
+++ b/pages/customize/index.vue
@@ -1,0 +1,23 @@
+<template>
+  <view class="page">
+    <text class="title">周边定制</text>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {};
+  }
+};
+</script>
+
+<style scoped>
+.page {
+  padding: 40rpx;
+  text-align: center;
+}
+.title {
+  font-size: 32rpx;
+}
+</style>

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -1,52 +1,51 @@
 <template>
-	<view class="content">
-		<image class="logo" src="/static/logo.png"></image>
-		<view class="text-area">
-			<text class="title">{{title}}</text>
-		</view>
-	</view>
+  <view class="content">
+    <image class="logo" src="/static/logo.png"></image>
+    <view class="grid">
+      <navigator url="/pages/customize/index" class="nav-item">周边定制</navigator>
+      <navigator url="/pages/templates/index" class="nav-item">模板市场</navigator>
+      <navigator url="/pages/store/index" class="nav-item">成品商城</navigator>
+      <navigator url="/pages/profile/index" class="nav-item">我的</navigator>
+    </view>
+  </view>
 </template>
 
 <script>
-	export default {
-		data() {
-			return {
-				title: 'Hello 谷苏良匠！'
-			}
-		},
-		onLoad() {
-
-		},
-		methods: {
-
-		}
-	}
+export default {
+  data() {
+    return {
+      title: 'Hello 谷苏良匠！'
+    };
+  }
+};
 </script>
 
-<style>
-	.content {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.logo {
-		height: 200rpx;
-		width: 200rpx;
-		margin-top: 200rpx;
-		margin-left: auto;
-		margin-right: auto;
-		margin-bottom: 50rpx;
-	}
-
-	.text-area {
-		display: flex;
-		justify-content: center;
-	}
-
-	.title {
-		font-size: 36rpx;
-		color: #8f8f94;
-	}
+<style scoped>
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.logo {
+  height: 200rpx;
+  width: 200rpx;
+  margin-top: 200rpx;
+  margin-bottom: 50rpx;
+}
+.grid {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.nav-item {
+  width: 40%;
+  margin: 10rpx;
+  padding: 20rpx 0;
+  background: #f0f0f0;
+  text-align: center;
+  border-radius: 8rpx;
+  font-size: 28rpx;
+}
 </style>

--- a/pages/profile/index.vue
+++ b/pages/profile/index.vue
@@ -1,0 +1,23 @@
+<template>
+  <view class="page">
+    <text class="title">我的</text>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {};
+  }
+};
+</script>
+
+<style scoped>
+.page {
+  padding: 40rpx;
+  text-align: center;
+}
+.title {
+  font-size: 32rpx;
+}
+</style>

--- a/pages/store/index.vue
+++ b/pages/store/index.vue
@@ -1,0 +1,23 @@
+<template>
+  <view class="page">
+    <text class="title">成品商城</text>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {};
+  }
+};
+</script>
+
+<style scoped>
+.page {
+  padding: 40rpx;
+  text-align: center;
+}
+.title {
+  font-size: 32rpx;
+}
+</style>

--- a/pages/templates/index.vue
+++ b/pages/templates/index.vue
@@ -1,0 +1,23 @@
+<template>
+  <view class="page">
+    <text class="title">模板市场</text>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {};
+  }
+};
+</script>
+
+<style scoped>
+.page {
+  padding: 40rpx;
+  text-align: center;
+}
+.title {
+  font-size: 32rpx;
+}
+</style>


### PR DESCRIPTION
## Summary
- add empty pages for customization, template marketplace, store and profile
- update home page with navigation to new pages
- register pages in `pages.json`
- document starter modules in README

## Testing
- `npm run build:h5` *(fails: `uni` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856968f1de883278754c93abfaa6596